### PR TITLE
Better restart, stop handling, AM-1361

### DIFF
--- a/lib/donaghy.rb
+++ b/lib/donaghy.rb
@@ -194,6 +194,11 @@ module Donaghy
     @configuration = @storage = @local_storage = @message_queue = @logger = @event_publisher = @middleware = nil
   end
 
+  at_exit do
+    message_queue.disconnect if message_queue.respond_to?(:disconnect)
+    storage.disconnect if storage.respond_to?(:disconnect)
+  end
+
 end
 
 $: << File.dirname(__FILE__)

--- a/lib/donaghy/event_handler.rb
+++ b/lib/donaghy/event_handler.rb
@@ -10,6 +10,8 @@ module Donaghy
     include Celluloid
     include Logging
 
+    finalizer :terminate_beater
+
     def self.default_middleware
       Middleware::Chain.new do |c|
         c.add Middleware::Retry
@@ -32,20 +34,18 @@ module Donaghy
     def handle(event)
       self.beater = HeartBeater.new_link(event, current_actor, beat_timeout)
       beater.async.beat
-      defer do
-        Donaghy.middleware.execute(event, uid: uid, only_distribute: only_distribute, manager_name: manager.name) do
-          if only_distribute
-            if event.path.start_with?('donaghy/')
-              logger.info("EventHandler #{uid} handling #{event.id}(#{event.path}) locally")
-              handle_locally(event)
-            else
-              logger.info("EventHandler #{uid} is remote distributing #{event.id}(#{event.path})")
-              RemoteDistributor.new.handle_distribution(event)
-            end
-          else
-            logger.debug("EventHandler #{uid} handling #{event.id}(#{event.path}) locally")
+      Donaghy.middleware.execute(event, uid: uid, only_distribute: only_distribute, manager_name: manager.name) do
+        if only_distribute
+          if event.path.start_with?('donaghy/')
+            logger.info("EventHandler #{uid} handling #{event.id}(#{event.path}) locally")
             handle_locally(event)
+          else
+            logger.info("EventHandler #{uid} is remote distributing #{event.id}(#{event.path})")
+            RemoteDistributor.new.handle_distribution(event)
           end
+        else
+          logger.debug("EventHandler #{uid} handling #{event.id}(#{event.path}) locally")
+          handle_locally(event)
         end
       end
       logger.debug("EventHandler #{uid} completed #{event.id}(#{event.path}), acknowledging event")
@@ -70,9 +70,8 @@ module Donaghy
       end
     end
 
-    def terminate
-      beater.terminate if beater and beater.alive?
-      super
+    def terminate_beater
+      beater.async.terminate if beater and beater.alive?
     end
 
   end

--- a/lib/donaghy/fetcher.rb
+++ b/lib/donaghy/fetcher.rb
@@ -26,15 +26,15 @@ module Donaghy
         if evt
           logger.debug("#{manager_name} fetcher received evt #{evt.id}(#{evt.path})")
           evt.received_on = queue
-          manager.async.handle_event(evt)
+          manager.async.handle_event(evt) unless done?
         else
-          after(0) { fetch } unless done?
+          async.fetch unless done?
         end
       end
     end
 
     def done?
-      !manager.alive? or @stopped
+      @stopped or !manager.alive?
     end
 
     def cleanup

--- a/lib/donaghy/heart_beater.rb
+++ b/lib/donaghy/heart_beater.rb
@@ -4,18 +4,19 @@ module Donaghy
 
     finalizer :cleanup
 
-    attr_reader :event, :timeout, :timer, :handler
+    attr_reader :event, :timeout, :handler
     def initialize(event, handler, timeout=5)
       @handler = handler
       @event = event
       @timeout = timeout
       @timer = nil
+      @stopped = false
     end
 
     def beat
       event.heartbeat(timeout*3) #we multiply by 3 to account for errors
       @timer = after(timeout) do
-        if current_actor.alive? and handler.alive?
+        if current_actor.alive? and handler.alive? and !@stopped
           beat
         elsif !handler.alive?
           terminate
@@ -25,7 +26,8 @@ module Donaghy
     end
 
     def cleanup
-      timer.cancel unless timer.nil?
+      @stopped = true
+      @timer.cancel unless @timer.nil?
     end
   end
 end

--- a/lib/donaghy/version.rb
+++ b/lib/donaghy/version.rb
@@ -1,3 +1,3 @@
 module Donaghy
-  VERSION = "0.2.10"
+  VERSION = "0.2.11"
 end

--- a/spec/lib/donaghy/event_handler_spec.rb
+++ b/spec/lib/donaghy/event_handler_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Donaghy
   describe EventHandler do
     let(:mock_async) { mock(:real_manager, event_handler_finished: true) }
-    let(:mock_manager) { mock(:async_manager, async: mock_async, name: "test_mocked_manager") }
+    let(:mock_manager) { mock(:async_manager, alive?: true, async: mock_async, name: "test_mocked_manager") }
 
     let(:handler) { EventHandler.new(mock_manager) }
 

--- a/spec/lib/donaghy/heart_beater_spec.rb
+++ b/spec/lib/donaghy/heart_beater_spec.rb
@@ -23,11 +23,5 @@ module Donaghy
       beater.beat
     end
 
-    it "should set the timer" do
-      beater.timer.should be_nil
-      beater.beat
-      beater.timer.should_not be_nil
-      beater.timer.interval.should == timeout
-    end
   end
 end

--- a/spec/lib/donaghy/middleware/retry_spec.rb
+++ b/spec/lib/donaghy/middleware/retry_spec.rb
@@ -26,7 +26,7 @@ module Donaghy
       end
 
       after do
-        event_handler.terminate if event_handler.alive?
+        event_handler.async.terminate if event_handler.alive?
       end
 
       before do

--- a/spec/support/cleaner.rb
+++ b/spec/support/cleaner.rb
@@ -1,4 +1,5 @@
 require 'logger'
+FileUtils.mkdir_p('tmp')
 LOGGER = Logger.new('tmp/test.log')
 
 RSpec.configure do |config|

--- a/spec/support/cleaner.rb
+++ b/spec/support/cleaner.rb
@@ -1,9 +1,14 @@
+require 'logger'
+LOGGER = Logger.new('tmp/test.log')
+
 RSpec.configure do |config|
   config.before do
     Donaghy.logger.info('storage flush')
     Donaghy.storage.flush
     Donaghy.reset
     Donaghy.configuration = {config_file: "spec/support/test_config.yml" }
+
+    Donaghy.logger = LOGGER
 
     if Donaghy.configuration[:storage] == :sqs
       while Donaghy.root_queue.length > 0


### PR DESCRIPTION
@zonotope 

So... i was able to _keep_ restarting this one over and over and while it took some time after a ton of restarts, it kept processing messages the whole time, so it seems like it's good to go (I know I've said that before).

Basically, this uses more of Celluloids features and does some more shutdown tasks async, which means they are all happening at once, etc.  I haven't seen any of the timeout logs since using this branch.
